### PR TITLE
fix import case

### DIFF
--- a/packages/governance/src/views/governance/GovernanceView.tsx
+++ b/packages/governance/src/views/governance/GovernanceView.tsx
@@ -12,7 +12,7 @@ import {
   useConnectionConfig,
   useMint,
 } from '@oyster/common';
-import { AddNewProposal } from './newProposal';
+import { AddNewProposal } from './NewProposal';
 import { useKeyParam } from '../../hooks/useKeyParam';
 import { Proposal, ProposalState } from '../../models/accounts';
 import { ClockCircleOutlined } from '@ant-design/icons';


### PR DESCRIPTION
was causing issues when building locally:

```
governance: Failed to compile.
governance: ./src/views/governance/GovernanceView.tsx
governance: Cannot find file: 'newProposal.tsx' does not match the corresponding name on disk: './src/views/governance/NewProposal.tsx'.
```