### PR TITLE
bridge: remove assets table from homepage

### DIFF
--- a/packages/bridge/src/views/home/index.tsx
+++ b/packages/bridge/src/views/home/index.tsx
@@ -1,13 +1,8 @@
 import anime from 'animejs';
 import React from 'react';
-import { formatUSD, shortenAddress } from '@oyster/common';
 import './itemStyle.less';
 import './index.less';
 import { Link } from 'react-router-dom';
-import { useWormholeAccounts } from '../../hooks/useWormholeAccounts';
-import { TokenDisplay } from '../../components/TokenDisplay';
-import { toChainSymbol } from '../../contexts/chainPair';
-import { AssetsTable } from '../../components/AssetsTable';
 
 export const HomeView = () => {
   const handleDownArrow = () => {
@@ -78,7 +73,7 @@ export const HomeView = () => {
             </div>
           </div>
         </div>
-        <AssetsTable />
+        {/* <AssetsTable /> */}
       </div>
     </>
   );


### PR DESCRIPTION
The assets table spams https://api.mainnet-beta.solana.com/
At least removing the one from the homepage to prevent users who visit to migrate from spamming rpc.