### PR TITLE
Round getMintMaxVoteWeight

### DIFF
--- a/packages/governance/src/tools/units.ts
+++ b/packages/governance/src/tools/units.ts
@@ -199,5 +199,7 @@ export function getMintMaxVoteWeight(
     .multipliedBy(mint.supply.toString())
     .shiftedBy(-MintMaxVoteWeightSource.SUPPLY_FRACTION_DECIMALS);
 
-  return new BN(maxVoteWeight.toString());
+  const roundedNumber = Math.floor(Number(maxVoteWeight.toString()));
+
+  return new BN(String(roundedNumber));
 }


### PR DESCRIPTION
Fixes “Invalid character” error due to maxVoteWeight having decimals. Rounds down maxVoteWeight using Math.floor to a whole number