### PR TITLE
fix getMintNaturalAmountFromDecimal for large threshold

### DIFF
--- a/packages/governance/src/tools/units.ts
+++ b/packages/governance/src/tools/units.ts
@@ -58,7 +58,7 @@ export function getMintNaturalAmountFromDecimal(
   decimalAmount: number,
   decimals: number,
 ) {
-  return new BigNumber(decimalAmount).shiftedBy(decimals).toNumber();
+  return new BigNumber(decimalAmount.toString()).shiftedBy(decimals).toNumber();
 }
 
 // Calculates percentage (provided as 0-100) of mint supply as decimal amount


### PR DESCRIPTION
fix #436 