### PR TITLE
fix/governance/MinCommunityTokensToCreateProposal

### DIFF
--- a/packages/governance/src/components/governanceConfigFormItem/governanceConfigFormItem.tsx
+++ b/packages/governance/src/components/governanceConfigFormItem/governanceConfigFormItem.tsx
@@ -46,7 +46,7 @@ export function getGovernanceConfig(values: GovernanceConfigValues) {
     voteThresholdPercentage: new VoteThresholdPercentage({
       value: values.voteThresholdPercentage,
     }),
-    minCommunityTokensToCreateProposal: new BN(minTokensToCreateProposal),
+    minCommunityTokensToCreateProposal: new BN(minTokensToCreateProposal.toString()),
     minInstructionHoldUpTime: getTimestampFromDays(
       values.minInstructionHoldUpTime,
     ),


### PR DESCRIPTION
So we can set the governance-config to have a very high MinCommunityTokensToCreateProposal threshold 
It was resulting in a error if the input was too high