### PR TITLE
governance: set up jest for tests

### DIFF
--- a/packages/governance-sdk/package.json
+++ b/packages/governance-sdk/package.json
@@ -45,7 +45,13 @@
   },
   "jest": {
     "transform": {
-      "^.+\\.tsx?$": "esbuild-jest"
-    }
+      "^.+\\.[jt]sx?$": "esbuild-jest"
+    },
+    "setupFiles": [
+      "./tests/setupTests.js"
+    ],
+    "transformIgnorePatterns": [
+      "<rootDir>/node_modules/(?!node-fetch)"
+    ]
   }
 }

--- a/packages/governance-sdk/package.json
+++ b/packages/governance-sdk/package.json
@@ -34,13 +34,13 @@
     "borsh": "^0.3.1",
     "bs58": "^4.0.1",
     "moment": "^2.29.1",
-    "node-fetch": "^3.1.0",
     "superstruct": "^0.15.2"
   },
   "devDependencies": {
     "esbuild": "^0.14.11",
     "esbuild-jest": "^0.5.0",
     "jest": "^27.4.7",
+    "node-fetch": "^3.1.0",
     "typescript": "^4.5.4"
   },
   "jest": {

--- a/packages/governance-sdk/package.json
+++ b/packages/governance-sdk/package.json
@@ -44,6 +44,7 @@
     "typescript": "^4.5.4"
   },
   "jest": {
+    "testTimeout": 20000,
     "transform": {
       "^.+\\.[jt]sx?$": "esbuild-jest"
     },

--- a/packages/governance-sdk/tests/governance/api.test.ts
+++ b/packages/governance-sdk/tests/governance/api.test.ts
@@ -1,9 +1,3 @@
-import fetch from 'node-fetch'
-
-
-var globalRef: any = global;
-globalRef.fetch = fetch
-
 import { PublicKey } from '@solana/web3.js';
 import { getTokenOwnerRecordsByOwner } from '../../src'
 

--- a/packages/governance-sdk/tests/setupTests.js
+++ b/packages/governance-sdk/tests/setupTests.js
@@ -1,0 +1,3 @@
+import fetch from 'node-fetch';
+
+global.fetch = fetch;


### PR DESCRIPTION
@SebastianBor this PR is based on your `governance-sdk-tests` branch so that you can continue to work on it if it gets merged into it.

It should fix `yarn test` but I don't know if you'll want to run tests like these against localnet or mainnet?