### PR TITLE
governance: remove moment

### DIFF
--- a/packages/governance-sdk/package.json
+++ b/packages/governance-sdk/package.json
@@ -33,7 +33,6 @@
     "bn.js": "^5.1.3",
     "borsh": "^0.3.1",
     "bs58": "^4.0.1",
-    "moment": "^2.29.1",
     "superstruct": "^0.15.2"
   },
   "devDependencies": {

--- a/packages/governance-sdk/src/governance/accounts.ts
+++ b/packages/governance-sdk/src/governance/accounts.ts
@@ -3,7 +3,6 @@ import BN from 'bn.js';
 import BigNumber from 'bignumber.js';
 import { Vote, VoteKind } from './instructions';
 import { PROGRAM_VERSION_V1, PROGRAM_VERSION_V2 } from '../registry/constants';
-import moment from 'moment';
 
 /// Seed  prefix for Governance Program PDAs
 export const GOVERNANCE_PROGRAM_SEED = 'governance';
@@ -728,13 +727,13 @@ export class Proposal {
   }
 
   getTimeToVoteEnd(governance: Governance) {
-    const now = moment().unix();
+    const unixTimestampInSeconds = Date.now() / 1000;
 
     return this.isPreVotingState()
       ? governance.config.maxVotingTime
       : (this.votingAt?.toNumber() ?? 0) +
           governance.config.maxVotingTime -
-          now;
+          unixTimestampInSeconds;
   }
 
   hasVoteTimeEnded(governance: Governance) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16113,7 +16113,7 @@ module-not-found-error@^1.0.1:
   resolved "https://registry.yarnpkg.com/module-not-found-error/-/module-not-found-error-1.0.1.tgz#cf8b4ff4f29640674d6cdd02b0e3bc523c2bbdc0"
   integrity sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=
 
-moment@^2.10.2, moment@^2.24.0, moment@^2.25.3, moment@^2.27.0, moment@^2.29.1:
+moment@^2.10.2, moment@^2.24.0, moment@^2.25.3, moment@^2.27.0:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==


### PR DESCRIPTION
A suggestion to remove moment.js from the governance SDK as it's quite a large and old library.

It is being used by other packages in this repo though and as dependencies are shared anyway due to the fact it's a lerna project, perhaps there isn't much of an incentive to do this.

Moment's [README](https://github.com/moment/moment#readme) states -

> Moment.js is a legacy project, now in maintenance mode. In most cases, you should choose a different library.

If a date utilities library is required for more advanced work it could be good to use something smaller and more modern like [date-fns](https://github.com/date-fns/date-fns) or [dayjs](https://github.com/iamkun/dayjs)

References:

https://bundlephobia.com/package/moment@2.29.1
https://github.com/you-dont-need/You-Dont-Need-Momentjs