### PR TITLE
test(governance-sdk): increase default testTimeout for jest

### DIFF
--- a/packages/governance-sdk/package.json
+++ b/packages/governance-sdk/package.json
@@ -43,6 +43,7 @@
     "@solana/spl-token": "0.1.3"
   },
   "jest": {
+    "testTimeout": 20000,
     "transform": {
       "^.+\\.tsx?$": "esbuild-jest"
     }


### PR DESCRIPTION
the current test in gov-sdk takes approx 10s for me

the default jest timeout for tests is 5s

you can set a longer timeout on a case-by-case basis, or globally in the config like this. I arbitrarily set it to 20s here but am happy to close this PR if it's not deemed necessary