### PR TITLE
simulate a whole proposal at once

### DIFF
--- a/packages/governance/src/actions/dryRunInstruction.ts
+++ b/packages/governance/src/actions/dryRunInstruction.ts
@@ -1,18 +1,26 @@
-import { InstructionData } from '@solana/spl-governance';
-import { RpcContext } from '@solana/spl-governance';
+import { InstructionData, RpcContext } from '@solana/spl-governance';
 import { simulateTransaction } from '@oyster/common';
 import { Transaction } from '@solana/web3.js';
 
 export async function dryRunInstruction(
-  { connection, wallet }: RpcContext,
+  rpc: RpcContext,
   instructionData: InstructionData,
 ) {
+  return dryRunInstructions(rpc, [instructionData]);
+}
+
+export async function dryRunInstructions(
+  { connection, wallet }: RpcContext,
+  instructions: InstructionData[],
+) {
   let transaction = new Transaction({ feePayer: wallet!.publicKey });
-  transaction.add({
-    keys: instructionData.accounts,
-    programId: instructionData.programId,
-    data: Buffer.from(instructionData.data),
-  });
+
+  for (let ins of instructions)
+    transaction.add({
+      keys: ins.accounts,
+      programId: ins.programId,
+      data: Buffer.from(ins.data),
+    });
 
   const result = await simulateTransaction(
     connection,

--- a/packages/governance/src/views/proposal/proposalView.tsx
+++ b/packages/governance/src/views/proposal/proposalView.tsx
@@ -43,6 +43,7 @@ import { useRealm } from '../../contexts/GovernanceContext';
 import { getMintMaxVoteWeight } from '../../tools/units';
 import { ProposalActionBar } from './components/buttons/proposalActionBar';
 import { ProgramAccount } from '@solana/spl-governance';
+import { DryRunProposalButton } from './components/instruction/buttons/dryRunProposalButton';
 
 const { TabPane } = Tabs;
 
@@ -445,6 +446,16 @@ function InnerProposalView({
                 </TabPane>
               )}
               <TabPane tab={LABELS.INSTRUCTIONS} key="instructions">
+                <Row
+                  align="middle"
+                  justify="end"
+                  style={{ paddingBottom: '1em' }}
+                >
+                  <DryRunProposalButton
+                    proposal={proposal}
+                    instructions={instructions}
+                  />
+                </Row>
                 <Row
                   gutter={[
                     { xs: 8, sm: 16, md: 24, lg: 32 },


### PR DESCRIPTION
Adds a button to simulate a whole proposal at once, complex proposals with multiple instructions sometimes can't simulate each instruction in isolation.