### PR TITLE
disallow crawling - reduce traffic

### DIFF
--- a/packages/bridge/public/robots.txt
+++ b/packages/bridge/public/robots.txt
@@ -1,3 +1,3 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow:
+Disallow: *


### PR DESCRIPTION
Want to prevent new users from finding and using the V1 bridge