### PR TITLE
Export withSetRealmConfig

### DIFF
--- a/packages/governance-sdk/src/governance/index.ts
+++ b/packages/governance-sdk/src/governance/index.ts
@@ -27,6 +27,7 @@ export * from './withInsertTransaction';
 export * from './withRelinquishVote';
 export * from './withRemoveTransaction';
 export * from './withSetRealmAuthority';
+export * from './withSetRealmConfig'
 export * from './withSetGovernanceDelegate';
 export * from './withSignOffProposal';
 export * from './withUpdateProgramMetadata';


### PR DESCRIPTION
This function is not exposed by the SDK, but useful to update existing realms.