### PR TITLE
FIX: payer accounts not writable

### DIFF
--- a/packages/governance-sdk/package.json
+++ b/packages/governance-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana/spl-governance",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "SPL Governance Client API",
   "author": "Solana Maintainers <maintainers@solana.foundation>",
   "homepage": "https://github.com/solana-labs/oyster/blob/main/packages/governance-sdk/README.md",

--- a/packages/governance-sdk/src/governance/withAddSignatory.ts
+++ b/packages/governance-sdk/src/governance/withAddSignatory.ts
@@ -54,7 +54,7 @@ export const withAddSignatory = async (
     },
     {
       pubkey: payer,
-      isWritable: false,
+      isWritable: true,
       isSigner: true,
     },
     {

--- a/packages/governance-sdk/src/governance/withCastVote.ts
+++ b/packages/governance-sdk/src/governance/withCastVote.ts
@@ -89,7 +89,7 @@ export const withCastVote = async (
     },
     {
       pubkey: payer,
-      isWritable: false,
+      isWritable: true,
       isSigner: true,
     },
     {

--- a/packages/governance-sdk/src/governance/withCreateGovernance.ts
+++ b/packages/governance-sdk/src/governance/withCreateGovernance.ts
@@ -64,7 +64,7 @@ export const withCreateGovernance = async (
     },
     {
       pubkey: payer,
-      isWritable: false,
+      isWritable: true,
       isSigner: true,
     },
     {

--- a/packages/governance-sdk/src/governance/withCreateMintGovernance.ts
+++ b/packages/governance-sdk/src/governance/withCreateMintGovernance.ts
@@ -68,7 +68,7 @@ export const withCreateMintGovernance = async (
     },
     {
       pubkey: payer, // 5
-      isWritable: false,
+      isWritable: true,
       isSigner: true,
     },
     {

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -6,7 +6,7 @@
     "@blockworks-foundation/voter-stake-registry-client": "^0.1.6",
     "@oyster/common": "0.0.2",
     "@project-serum/borsh": "^0.2.2",
-    "@solana/spl-governance": "0.3.15",
+    "@solana/spl-governance": "0.3.16",
     "@solana/spl-token": "0.1.3",
     "@solana/web3.js": "^1.22.0",
     "antd": "^4.6.6",


### PR DESCRIPTION
updated `governance-sdk/governance` instructions where `payer` was not writable.