### PR TITLE
fixed vote options serialization

### DIFF
--- a/packages/governance-sdk/src/governance/serialisation.ts
+++ b/packages/governance-sdk/src/governance/serialisation.ts
@@ -111,8 +111,10 @@ import { deserializeBorsh } from '../tools/borsh';
   writer.length += 1;
 
   if (value.type === VoteTypeKind.MultiChoice) {
-    writer.buf.writeUInt16LE(value.choiceCount!, writer.length);
-    writer.length += 2;
+    writer.buf.writeUInt8(value.choiceCount!, writer.length);
+    writer.length += 1;
+    writer.buf.writeUInt8(value.choiceCount!, writer.length);
+    writer.length += 1;
   }
 };
 

--- a/packages/governance-sdk/tests/governance/api.v4.test.ts
+++ b/packages/governance-sdk/tests/governance/api.v4.test.ts
@@ -1,0 +1,83 @@
+import { Keypair } from '@solana/web3.js';
+import { GoverningTokenConfigAccountArgs, GoverningTokenType } from '../../src';
+import { BenchBuilder } from '../tools/builders';
+
+test('setRealmConfig', async () => {
+  // Arrange
+  const realm = await BenchBuilder.withConnection()
+    .then(b => b.withWallet())
+    .then(b => b.withRealm())
+    .then(b => b.sendTx());
+
+  const communityTokenConfig = new GoverningTokenConfigAccountArgs({
+    voterWeightAddin: Keypair.generate().publicKey,
+    maxVoterWeightAddin: Keypair.generate().publicKey,
+    tokenType: GoverningTokenType.Liquid,
+  });
+
+  // Act
+  await realm.setRealmConfig(communityTokenConfig);
+
+  // Assert
+  const realmConfig = await realm.getRealmConfig();
+
+  expect(realmConfig.account.realm).toEqual(realm.realmPk);
+
+  // communityTokenConfig
+  expect(realmConfig.account.communityTokenConfig.tokenType).toEqual(
+    communityTokenConfig.tokenType,
+  );
+  expect(realmConfig.account.communityTokenConfig.voterWeightAddin).toEqual(
+    communityTokenConfig.voterWeightAddin,
+  );
+  expect(realmConfig.account.communityTokenConfig.maxVoterWeightAddin).toEqual(
+    communityTokenConfig.maxVoterWeightAddin,
+  );
+
+  // councilTokenConfig
+  expect(realmConfig.account.councilTokenConfig.tokenType).toEqual(
+    GoverningTokenType.Liquid,
+  );
+  expect(realmConfig.account.councilTokenConfig.voterWeightAddin).toEqual(
+    undefined,
+  );
+  expect(realmConfig.account.councilTokenConfig.maxVoterWeightAddin).toEqual(
+    undefined,
+  );
+});
+
+test('createGovernance', async () => {
+  // Arrange
+  const realm = await BenchBuilder.withConnection()
+    .then(b => b.withWallet())
+    .then(b => b.withRealm())
+    .then(b => b.withCommunityMember())
+    .then(b => b.sendTx());
+
+  // Act
+  const governancePk = await realm.createGovernance();
+
+  // // Assert
+  const governance = await realm.getGovernance(governancePk);
+
+  expect(governance.account.realm).toEqual(realm.realmPk);
+});
+
+test('createProposal', async () => {
+  // Arrange
+  const realm = await BenchBuilder.withConnection()
+    .then(b => b.withWallet())
+    .then(b => b.withRealm())
+    .then(b => b.withCommunityMember())
+    .then(b => b.withGovernance())
+    .then(b => b.sendTx());
+
+  // Act
+  const proposalPk = await realm.createProposal('proposal 1', true);
+
+  // Assert
+  const proposal = await realm.getProposal(proposalPk);
+
+  expect(proposal.account.name).toEqual('proposal 1');
+  expect(proposal.account.vetoVoteWeight.toNumber()).toEqual(0);
+});

--- a/packages/governance-sdk/tests/tools/builders.ts
+++ b/packages/governance-sdk/tests/tools/builders.ts
@@ -379,17 +379,23 @@ export class RealmBuilder {
     return this;
   }
 
-  async createProposal(name?: string) {
-    const proposalPk = await this._createProposal(name);
+  async createProposal(name?: string, multiple?: boolean) {
+    const proposalPk = await this._createProposal(name, multiple);
     await this.sendTx();
     return proposalPk;
   }
 
-  async _createProposal(name?: string) {
+  async _createProposal(name?: string, multiple?: boolean) {
     // Create single choice Approve/Deny proposal with instruction to mint more governance tokens
-    const voteType = VoteType.SINGLE_CHOICE;
-    const options = ['Approve'];
-    const useDenyOption = true;
+    let voteType = VoteType.SINGLE_CHOICE;
+    let options = ['Approve'];
+    let useDenyOption = true;
+
+    if (multiple) {
+      voteType = VoteType.MULTI_CHOICE(4);
+      options = ['One', 'Two', 'Three', 'four']
+      useDenyOption = false
+    }
 
     this.proposalPk = await withCreateProposal(
       this.bench.instructions,
@@ -408,7 +414,6 @@ export class RealmBuilder {
       useDenyOption,
       this.bench.walletPk,
     );
-
     return this.proposalPk;
   }
 


### PR DESCRIPTION
Fixed vote type serialization on Multiple choice vote type. It was using 16 bits but only sending one data, now it sends 2 option in the same 16 bits.

We also found a couple of inconsistencies!

- Deserialization might not be working since [VoteType Class in SDK](https://github.com/solana-labs/oyster/blob/main/packages/governance-sdk/src/governance/accounts.ts#L202) does not match with [VoteType Enum in the program](https://github.com/solana-labs/solana-program-library/blob/6e8179484413cd8a50ee794c0a49cfef91e1fcb6/governance/program/src/state/proposal.rs#L79)
- I don't think the [specification](https://github.com/solana-labs/solana-program-library/blob/6e8179484413cd8a50ee794c0a49cfef91e1fcb6/governance/program/src/state/proposal.rs#L86) in the program can be fulfilled since there is [this validation](https://github.com/solana-labs/solana-program-library/blob/6e8179484413cd8a50ee794c0a49cfef91e1fcb6/governance/program/src/state/proposal.rs#L1036)