### PR TITLE
Governance: Fix MultiChoice VoteType serialization

### DIFF
--- a/packages/governance-sdk/src/governance/accounts.ts
+++ b/packages/governance-sdk/src/governance/accounts.ts
@@ -201,11 +201,13 @@ export enum VoteTypeKind {
 
 export class VoteType {
   type: VoteTypeKind;
-  choiceCount: number | undefined;
+  maxVoterOptions: number | undefined;
+  maxWinningOptions: number | undefined;
 
   constructor(args: { type: VoteTypeKind; choiceCount: number | undefined }) {
     this.type = args.type;
-    this.choiceCount = args.choiceCount;
+    this.maxVoterOptions = args.choiceCount;
+    this.maxWinningOptions = args.choiceCount;
   }
 
   static SINGLE_CHOICE = new VoteType({

--- a/packages/governance-sdk/src/governance/serialisation.ts
+++ b/packages/governance-sdk/src/governance/serialisation.ts
@@ -100,7 +100,8 @@ import { deserializeBorsh } from '../tools/borsh';
     return VoteType.SINGLE_CHOICE;
   }
 
-  const choiceCount = reader.buf.readUInt16LE(reader.offset);
+  const choiceCount = reader.buf.readUInt8(reader.offset);
+  reader.offset += 2; // skip two bytes
   return VoteType.MULTI_CHOICE(choiceCount);
 };
 
@@ -111,8 +112,11 @@ import { deserializeBorsh } from '../tools/borsh';
   writer.length += 1;
 
   if (value.type === VoteTypeKind.MultiChoice) {
-    writer.buf.writeUInt16LE(value.choiceCount!, writer.length);
-    writer.length += 2;
+    // maxVoterOptions and maxWinningOtions are not implemented at backend
+    writer.buf.writeUInt8(value.maxVoterOptions || 0, writer.length);
+    writer.length += 1;
+    writer.buf.writeUInt8(value.maxWinningOptions || 0, writer.length);
+    writer.length += 1;
   }
 };
 


### PR DESCRIPTION
Creating proposal of the `MultiChoice` `VoteType` running against the V3 (the most up-to-date `master` of `solana-program-library`) fails with `failed to send transaction: Transaction simulation failed: Error processing Instruction 0: invalid instruction data`.
As the V2 seems to get the same data structure (https://github.com/solana-labs/solana-program-library/blob/governance-v2.x/governance/program/src/state/proposal.rs#L88) this change should be right for both.

On this change I'm able to process the multichoice proposal creation.