### PR TITLE
Governance: time to vote eneded calculates with cool off time

### DIFF
--- a/packages/governance-sdk/src/governance/accounts.ts
+++ b/packages/governance-sdk/src/governance/accounts.ts
@@ -946,12 +946,13 @@ export class Proposal {
     return this.isPreVotingState()
       ? governance.config.maxVotingTime
       : (this.votingAt?.toNumber() ?? 0) +
-          governance.config.maxVotingTime -
+          governance.config.maxVotingTime +
+          governance.config.votingCoolOffTime -
           unixTimestampInSeconds;
   }
 
   hasVoteTimeEnded(governance: Governance) {
-    return this.getTimeToVoteEnd(governance) <= 0;
+    return this.getTimeToVoteEnd(governance) < 0;
   }
 
   canCancel(governance: Governance) {


### PR DESCRIPTION
The contract of SPL Gov works with cool off time to assert if it's time to finalize vote.
https://github.com/solana-labs/solana-program-library/blob/master/governance/program/src/state/proposal.rs#L340 While there is the greater than not with 'equal' in comparision.