### PR TITLE
throw an error if writing governance config and baseVotingTime < 1hr

### DIFF
--- a/packages/governance-sdk/src/governance/createSetGovernanceConfig.ts
+++ b/packages/governance-sdk/src/governance/createSetGovernanceConfig.ts
@@ -15,6 +15,10 @@ export function createSetGovernanceConfig(
     serialize(getGovernanceInstructionSchema(programVersion), args),
   );
 
+  if (args.config.baseVotingTime < 3600) {
+    throw new Error('baseVotingTime should be at least 1 hour');
+  }
+
   const keys = [
     {
       pubkey: governance,

--- a/packages/governance-sdk/src/governance/withCreateGovernance.ts
+++ b/packages/governance-sdk/src/governance/withCreateGovernance.ts
@@ -26,6 +26,10 @@ export const withCreateGovernance = async (
 ) => {
   const args = new CreateGovernanceArgs({ config });
 
+  if (args.config.baseVotingTime < 3600) {
+    throw new Error('baseVotingTime should be at least 1 hour');
+  }
+
   const data = Buffer.from(
     serialize(getGovernanceInstructionSchema(programVersion), args),
   );

--- a/packages/governance-sdk/src/governance/withCreateMintGovernance.ts
+++ b/packages/governance-sdk/src/governance/withCreateMintGovernance.ts
@@ -12,6 +12,7 @@ import { SYSTEM_PROGRAM_ID } from '../tools/sdk/runtime';
 import { withRealmConfigPluginAccounts } from './withRealmConfigPluginAccounts';
 import { PROGRAM_VERSION_V1 } from '../registry/constants';
 
+/** @deprecated */
 export const withCreateMintGovernance = async (
   instructions: TransactionInstruction[],
   programId: PublicKey,

--- a/packages/governance-sdk/src/governance/withCreateProgramGovernance.ts
+++ b/packages/governance-sdk/src/governance/withCreateProgramGovernance.ts
@@ -12,6 +12,7 @@ import { BPF_UPGRADE_LOADER_ID } from '../tools/sdk/bpfUpgradeableLoader';
 import { withRealmConfigPluginAccounts } from './withRealmConfigPluginAccounts';
 import { PROGRAM_VERSION_V1 } from '../registry/constants';
 
+/** @deprecated */
 export const withCreateProgramGovernance = async (
   instructions: TransactionInstruction[],
   programId: PublicKey,

--- a/packages/governance-sdk/src/governance/withCreateTokenGovernance.ts
+++ b/packages/governance-sdk/src/governance/withCreateTokenGovernance.ts
@@ -12,6 +12,7 @@ import { TOKEN_PROGRAM_ID } from '../tools/sdk/splToken';
 import { withRealmConfigPluginAccounts } from './withRealmConfigPluginAccounts';
 import { PROGRAM_VERSION_V1 } from '../registry/constants';
 
+/** @deprecated */
 export const withCreateTokenGovernance = async (
   instructions: TransactionInstruction[],
   programId: PublicKey,


### PR DESCRIPTION
If baseVotingTime is zero, your governance is bricked. Ideally the program should bar this, but in meantime the SDK can too. I decided an hour was a reasonable minimum, but maybe it should be something else.