### PR TITLE
Governance: Fix VoteType enum

### DIFF
--- a/packages/governance-sdk/src/governance/accounts.ts
+++ b/packages/governance-sdk/src/governance/accounts.ts
@@ -209,24 +209,52 @@ export enum VoteTypeKind {
   MultiChoice = 1,
 }
 
+export enum MultiChoiceType {
+  FullWeight = 0,
+  Weighted = 1,
+}
+
 export class VoteType {
   type: VoteTypeKind;
-  choiceCount: number | undefined;
+  choiceType: MultiChoiceType | undefined;
+  minVoterOptions: number | undefined;
+  maxVoterOptions: number | undefined;
+  maxWinningOptions: number | undefined;
 
-  constructor(args: { type: VoteTypeKind; choiceCount: number | undefined }) {
+  constructor(args: {
+    type: VoteTypeKind;
+    choiceType: MultiChoiceType | undefined;
+    minVoterOptions: number | undefined;
+    maxVoterOptions: number | undefined;
+    maxWinningOptions: number | undefined;
+  }) {
     this.type = args.type;
-    this.choiceCount = args.choiceCount;
+    this.choiceType = args.choiceType;
+    this.minVoterOptions = args.minVoterOptions;
+    this.maxVoterOptions = args.maxVoterOptions;
+    this.maxWinningOptions = args.maxWinningOptions;
   }
 
   static SINGLE_CHOICE = new VoteType({
     type: VoteTypeKind.SingleChoice,
-    choiceCount: undefined,
+    choiceType: undefined,
+    minVoterOptions: undefined,
+    maxVoterOptions: undefined,
+    maxWinningOptions: undefined,
   });
 
-  static MULTI_CHOICE = (choiceCount: number) =>
+  static MULTI_CHOICE = (
+    choiceType: MultiChoiceType,
+    minVoterOptions: number,
+    maxVoterOptions: number,
+    maxWinningOptions: number,
+  ) =>
     new VoteType({
       type: VoteTypeKind.MultiChoice,
-      choiceCount: choiceCount,
+      choiceType,
+      minVoterOptions,
+      maxVoterOptions,
+      maxWinningOptions,
     });
 
   isSingleChoice() {

--- a/packages/governance-sdk/src/governance/serialisation.ts
+++ b/packages/governance-sdk/src/governance/serialisation.ts
@@ -102,8 +102,21 @@ import { deserializeBorsh } from '../tools/borsh';
     return VoteType.SINGLE_CHOICE;
   }
 
-  const choiceCount = reader.buf.readUInt16LE(reader.offset);
-  return VoteType.MULTI_CHOICE(choiceCount);
+  const choiceType = reader.buf.readUInt8(reader.offset);
+  reader.offset += 1;
+  const minVoterOptions = reader.buf.readUInt8(reader.offset);
+  reader.offset += 1;
+  const maxVoterOptions = reader.buf.readUInt8(reader.offset);
+  reader.offset += 1;
+  const maxWinningOptions = reader.buf.readUInt8(reader.offset);
+  reader.offset += 1;
+
+  return VoteType.MULTI_CHOICE(
+    choiceType,
+    minVoterOptions,
+    maxVoterOptions,
+    maxWinningOptions,
+  );
 };
 
 (BinaryWriter.prototype as any).writeVoteType = function (value: VoteType) {
@@ -113,8 +126,14 @@ import { deserializeBorsh } from '../tools/borsh';
   writer.length += 1;
 
   if (value.type === VoteTypeKind.MultiChoice) {
-    writer.buf.writeUInt16LE(value.choiceCount!, writer.length);
-    writer.length += 2;
+    writer.buf.writeUInt8(value.choiceType!, writer.length);
+    writer.length += 1;
+    writer.buf.writeUInt8(value.minVoterOptions!, writer.length);
+    writer.length += 1;
+    writer.buf.writeUInt8(value.maxVoterOptions!, writer.length);
+    writer.length += 1;
+    writer.buf.writeUInt8(value.maxWinningOptions!, writer.length);
+    writer.length += 1;
   }
 };
 


### PR DESCRIPTION
The ``MULTI_CHOICE`` type in ``VoteType`` enum is wrongly configured. The type has four fields - ChoiceType, minVoterOptions, maxVoterOptions and maxWinningOptions, but currently it is wrongly configured to cover only one type - ChoiceCount. 

As a result, ``withCreateProposal`` function can't handle the creation of multi-choice proposals and ``getProposal`` api can't deserialize the multi-choice proposal. 